### PR TITLE
beholder opprinnelig overordnet enhet hvis underenhet slettes/fjernes

### DIFF
--- a/src/main/kotlin/no/nav/amt_enhetsregister/service/DeltaOppdateringEnhetService.kt
+++ b/src/main/kotlin/no/nav/amt_enhetsregister/service/DeltaOppdateringEnhetService.kt
@@ -59,31 +59,34 @@ class DeltaOppdateringEnhetService(
 
 			if (underenhet == null) { // GONE
 				log.info("Underenhet orgnr=${it.organisasjonsnummer} er fjernet fra brreg")
+				val opprinneligOverordnetEnhet = enhetService.hentEnhet(it.organisasjonsnummer)?.overordnetEnhetOrganisasjonsnummer
 
 				return@deltaOppdaterEnhet EnhetService.UpsertEnhet(
 					organisasjonsnummer = it.organisasjonsnummer,
 					navn = "Fjernet virksomhet",
-					overordnetEnhetOrgNr = UKJENT_VIRKSOMHET_NR
+					overordnetEnhetOrgNr = opprinneligOverordnetEnhet
 				)
 			}
 
 			if (underenhet.slettedato != null) {
 				log.info("Underenhet orgnr=${it.organisasjonsnummer} er slettet fra brreg")
+				val opprinneligOverordnetEnhet = enhetService.hentEnhet(it.organisasjonsnummer)?.overordnetEnhetOrganisasjonsnummer
 
 				return@deltaOppdaterEnhet EnhetService.UpsertEnhet(
 					organisasjonsnummer = it.organisasjonsnummer,
 					navn = "${underenhet.navn} (slettet)",
-					overordnetEnhetOrgNr = UKJENT_VIRKSOMHET_NR
+					overordnetEnhetOrgNr = opprinneligOverordnetEnhet
 				)
 			}
 
 			if (underenhet.overordnetEnhet == null) {
 				log.warn("Underenhet orgnr=${underenhet.organisasjonsnummer} mangler overordnet enhet. oppdatering_id=${it.oppdateringId}")
+				val opprinneligOverordnetEnhet = enhetService.hentEnhet(it.organisasjonsnummer)?.overordnetEnhetOrganisasjonsnummer
 
 				return@deltaOppdaterEnhet EnhetService.UpsertEnhet(
 					organisasjonsnummer = it.organisasjonsnummer,
 					navn = underenhet.navn,
-					overordnetEnhetOrgNr = UKJENT_VIRKSOMHET_NR
+					overordnetEnhetOrgNr = opprinneligOverordnetEnhet
 				)
 			}
 

--- a/src/main/kotlin/no/nav/amt_enhetsregister/service/DeltaOppdateringEnhetService.kt
+++ b/src/main/kotlin/no/nav/amt_enhetsregister/service/DeltaOppdateringEnhetService.kt
@@ -16,7 +16,6 @@ class DeltaOppdateringEnhetService(
 
 	companion object {
 		const val OPPDATERINGER_SIZE = 500
-		const val UKJENT_VIRKSOMHET_NR = "999999999"
 	}
 
 	private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/no/nav/amt_enhetsregister/service/EnhetService.kt
+++ b/src/main/kotlin/no/nav/amt_enhetsregister/service/EnhetService.kt
@@ -43,7 +43,7 @@ class EnhetService(
 				listOf( UpsertEnhet(
 				organisasjonsnummer = organisasjonsnummer,
 				navn = "${underEnhet.navn}${if (underEnhet.slettedato == null) SLETTET_SUFFIX else EMPTY_STRING}",
-				overordnetEnhetOrgNr = underEnhet.overordnetEnhet ?: DeltaOppdateringEnhetService.UKJENT_VIRKSOMHET_NR
+				overordnetEnhetOrgNr = underEnhet.overordnetEnhet
 			)))
 			if (underEnhet.overordnetEnhet != null) {
 				val moderEnhet = hentEnhet(underEnhet.overordnetEnhet)
@@ -59,7 +59,7 @@ class EnhetService(
 				return EnhetMedOverordnetEnhet(
 					organisasjonsnummer = organisasjonsnummer,
 					navn = "${underEnhet.navn}${if (underEnhet.slettedato != null) SLETTET_SUFFIX else EMPTY_STRING}",
-					overordnetEnhetOrganisasjonsnummer = DeltaOppdateringEnhetService.UKJENT_VIRKSOMHET_NR,
+					overordnetEnhetOrganisasjonsnummer = null,
 					overordnetEnhetNavn = null
 				)
 			}

--- a/src/test/kotlin/no/nav/amt_enhetsregister/service/DeltaOppdateringEnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt_enhetsregister/service/DeltaOppdateringEnhetServiceTest.kt
@@ -2,11 +2,14 @@ package no.nav.amt_enhetsregister.service
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.amt_enhetsregister.client.*
+import no.nav.amt_enhetsregister.client.BronnoysundClient
+import no.nav.amt_enhetsregister.client.EnhetOppdatering
+import no.nav.amt_enhetsregister.client.EnhetOppdateringType
+import no.nav.amt_enhetsregister.client.Moderenhet
+import no.nav.amt_enhetsregister.client.Underenhet
 import no.nav.amt_enhetsregister.repository.DeltaOppdateringProgresjonRepository
 import no.nav.amt_enhetsregister.repository.type.DeltaEnhetOppdateringProgresjon
 import no.nav.amt_enhetsregister.repository.type.EnhetType
-import no.nav.amt_enhetsregister.service.DeltaOppdateringEnhetService.Companion.UKJENT_VIRKSOMHET_NR
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
@@ -296,13 +299,22 @@ class DeltaOppdateringEnhetServiceTest {
 			navn = "Orgnavn",
 			slettedato = ZonedDateTime.now().toString(),
 			overordnetEnhet = null)
+		every { enhetService.hentEnhet("899000000")
+		} returns EnhetService.EnhetMedOverordnetEnhet(
+			organisasjonsnummer = "899000000",
+			navn = "Orgnavn",
+			overordnetEnhetOrganisasjonsnummer = "999000000",
+			overordnetEnhetNavn = "Moderenhetnavn"
+		)
+
 		deltaOppdateringEnhetService.deltaOppdaterUnderenheter()
+
 		verify(exactly = 1) {
 			enhetService.oppdaterEnheter(listOf(
 				EnhetService.UpsertEnhet(
 					organisasjonsnummer = "899000000",
 					navn = "Orgnavn (slettet)",
-					overordnetEnhetOrgNr = UKJENT_VIRKSOMHET_NR
+					overordnetEnhetOrgNr = "999000000"
 				)
 			))
 		}
@@ -322,13 +334,22 @@ class DeltaOppdateringEnhetServiceTest {
 		every {
 			bronnoysundClient.hentUnderenhet("899000000")
 		} returns null
+		every { enhetService.hentEnhet("899000000")
+		} returns EnhetService.EnhetMedOverordnetEnhet(
+			organisasjonsnummer = "899000000",
+			navn = "Orgnavn",
+			overordnetEnhetOrganisasjonsnummer = "999000000",
+			overordnetEnhetNavn = "Moderenhetnavn"
+		)
+
 		deltaOppdateringEnhetService.deltaOppdaterUnderenheter()
+
 		verify(exactly = 1) {
 			enhetService.oppdaterEnheter(listOf(
 				EnhetService.UpsertEnhet(
 					organisasjonsnummer = "899000000",
 					navn = "Fjernet virksomhet",
-					overordnetEnhetOrgNr = UKJENT_VIRKSOMHET_NR
+					overordnetEnhetOrgNr = "999000000"
 				)
 			))
 		}

--- a/src/test/kotlin/no/nav/amt_enhetsregister/service/EnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt_enhetsregister/service/EnhetServiceTest.kt
@@ -184,7 +184,7 @@ class EnhetServiceTest {
 		assertThat(enhet?.navn).isEqualTo("Underenhet1 (slettet)")
 		assertThat(enhet?.overordnetEnhetNavn).isNull()
 		assertThat(enhet?.organisasjonsnummer).isEqualTo(ORGNR_UNDERENHET)
-		assertThat(enhet?.overordnetEnhetOrganisasjonsnummer).isEqualTo(DeltaOppdateringEnhetService.UKJENT_VIRKSOMHET_NR)
+		assertThat(enhet?.overordnetEnhetOrganisasjonsnummer).isNull()
 
 		// Db oppdatert og kafkamelding publisert etter info hentet fra brreg
 		verify(exactly = 1) {


### PR DESCRIPTION
Vi forsøker å beholde den overordnede enheten man opprinnelig hadde i stedet for å sette en default-enhet. 