### PR TITLE
Bump dependencies - 20250613102108

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 val commonVersion = "3.2024.10.25_13.44-9db48a0dbe67"
 val testcontainersVersion = "1.21.1"
 val logstashEncoderVersion = "8.1"
-val shedlockVersion = "6.7.0"
+val shedlockVersion = "6.9.0"
 val tokenSupportVersion = "5.0.29"
 val okHttpVersion = "4.12.0"
 val mockOauth2ServerVersion = "2.1.11"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ val logstashEncoderVersion = "8.1"
 val shedlockVersion = "6.9.0"
 val tokenSupportVersion = "5.0.29"
 val okHttpVersion = "4.12.0"
-val mockOauth2ServerVersion = "2.1.11"
+val mockOauth2ServerVersion = "2.2.1"
 val mockkVersion = "1.14.2"
 
 dependencies {


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250613102108 branch:

## Successfully Rebased PRs
- [Bump no.nav.security:mock-oauth2-server from 2.1.11 to 2.2.1](https://github.com/navikt/amt-enhetsregister/pull/258)
- [Bump shedlockVersion from 6.7.0 to 6.9.0](https://github.com/navikt/amt-enhetsregister/pull/257)


