### PR TITLE
Bump dependencies - 20250623091842

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     val kotlinVersion = "2.1.21"
 
-    id("org.springframework.boot") version "3.5.0"
+    id("org.springframework.boot") version "3.5.3"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.spring") version kotlinVersion

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 }
 
 val commonVersion = "3.2024.10.25_13.44-9db48a0dbe67"
-val testcontainersVersion = "1.21.1"
+val testcontainersVersion = "1.21.2"
 val logstashEncoderVersion = "8.1"
 val shedlockVersion = "6.9.0"
 val tokenSupportVersion = "5.0.29"


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250623091842 branch:

## Successfully Rebased PRs
- [Bump org.springframework.boot from 3.5.0 to 3.5.3](https://github.com/navikt/amt-enhetsregister/pull/261)
- [Bump testcontainersVersion from 1.21.1 to 1.21.2](https://github.com/navikt/amt-enhetsregister/pull/260)


