### PR TITLE
Bump dependencies - 20250627145817

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    val kotlinVersion = "2.1.21"
+    val kotlinVersion = "2.2.0"
 
     id("org.springframework.boot") version "3.5.3"
     id("io.spring.dependency-management") version "1.1.7"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ val shedlockVersion = "6.9.0"
 val tokenSupportVersion = "5.0.30"
 val okHttpVersion = "4.12.0"
 val mockOauth2ServerVersion = "2.2.1"
-val mockkVersion = "1.14.2"
+val mockkVersion = "1.14.4"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250627145817 branch:

## Successfully Rebased PRs
- [Bump kotlinVersion from 2.1.21 to 2.2.0](https://github.com/navikt/amt-enhetsregister/pull/265)
- [Bump io.mockk:mockk from 1.14.2 to 1.14.4](https://github.com/navikt/amt-enhetsregister/pull/264)


