### PR TITLE
Bump dependencies - 20250704095114

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ val testcontainersVersion = "1.21.3"
 val logstashEncoderVersion = "8.1"
 val shedlockVersion = "6.9.0"
 val tokenSupportVersion = "5.0.30"
-val okHttpVersion = "4.12.0"
+val okHttpVersion = "5.0.0"
 val mockOauth2ServerVersion = "2.2.1"
 val mockkVersion = "1.14.4"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 }
 
 val commonVersion = "3.2024.10.25_13.44-9db48a0dbe67"
-val testcontainersVersion = "1.21.2"
+val testcontainersVersion = "1.21.3"
 val logstashEncoderVersion = "8.1"
 val shedlockVersion = "6.9.0"
 val tokenSupportVersion = "5.0.30"


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250704095114 branch:

## Successfully Rebased PRs
- [Bump okHttpVersion from 4.12.0 to 5.0.0](https://github.com/navikt/amt-enhetsregister/pull/268)
- [Bump testcontainersVersion from 1.21.2 to 1.21.3](https://github.com/navikt/amt-enhetsregister/pull/267)


