### PR TITLE
Bump dependencies - 20250708105920

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ val testcontainersVersion = "1.21.3"
 val logstashEncoderVersion = "8.1"
 val shedlockVersion = "6.9.2"
 val tokenSupportVersion = "5.0.30"
-val okHttpVersion = "5.0.0"
+val okHttpVersion = "5.1.0"
 val mockOauth2ServerVersion = "2.2.1"
 val mockkVersion = "1.14.4"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 val commonVersion = "3.2024.10.25_13.44-9db48a0dbe67"
 val testcontainersVersion = "1.21.3"
 val logstashEncoderVersion = "8.1"
-val shedlockVersion = "6.9.0"
+val shedlockVersion = "6.9.2"
 val tokenSupportVersion = "5.0.30"
 val okHttpVersion = "5.0.0"
 val mockOauth2ServerVersion = "2.2.1"


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250708105920 branch:

## Successfully Rebased PRs
- [Bump okHttpVersion from 5.0.0 to 5.1.0](https://github.com/navikt/amt-enhetsregister/pull/271)
- [Bump shedlockVersion from 6.9.0 to 6.9.2](https://github.com/navikt/amt-enhetsregister/pull/270)


