### PR TITLE
Byttet ut 'management.endpoint.prometheus.enabled' som er deprikert

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,7 @@
 spring.main.banner-mode=off
 server.shutdown=graceful
 
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
+management.endpoint.prometheus.access=read_only
 management.endpoint.health.probes.enabled=true
 management.endpoint.health.group.liveness.include=livenessState
 management.endpoints.web.base-path=/internal

--- a/src/test/kotlin/no/nav/amt_enhetsregister/ActuatorTest.kt
+++ b/src/test/kotlin/no/nav/amt_enhetsregister/ActuatorTest.kt
@@ -1,0 +1,57 @@
+package no.nav.amt_enhetsregister
+
+import no.nav.amt_enhetsregister.test_utils.IntegrationTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.server.LocalManagementPort
+import org.springframework.http.HttpStatus
+import org.springframework.web.util.UriComponentsBuilder
+
+class ActuatorTest(
+    @LocalManagementPort private val managementPort: Int,
+    private val restTemplate: TestRestTemplate,
+) : IntegrationTest() {
+    @ParameterizedTest(name = "{0} probe skal returnere OK og status = UP")
+    @ValueSource(strings = ["liveness", "readiness"])
+    fun probe_skal_returnere_OK_og_status_UP(probeName: String) {
+        val uri =
+            UriComponentsBuilder
+                .fromUriString("http://localhost:{port}/internal/health/{probeName}")
+                .buildAndExpand(managementPort, probeName)
+                .toUri()
+
+        val response = restTemplate.getForEntity(uri, String::class.java)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals("{\"status\":\"UP\"}", response.body)
+    }
+
+    @Test
+    fun `Prometheus-endepunktet skal returnere OK`() {
+        val uri =
+            UriComponentsBuilder
+                .fromUriString("http://localhost:{port}/internal/prometheus")
+                .buildAndExpand(managementPort)
+                .toUri()
+
+        val response = restTemplate.getForEntity(uri, String::class.java)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+    }
+
+    @Test
+    fun `Metrics-endepunktet skal returnere NOT_FOUND`() {
+        val uri =
+            UriComponentsBuilder
+                .fromUriString("http://localhost:{port}/internal/metrics")
+                .buildAndExpand(managementPort)
+                .toUri()
+
+        val response = restTemplate.getForEntity(uri, String::class.java)
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+    }
+}

--- a/src/test/kotlin/no/nav/amt_enhetsregister/test_utils/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/amt_enhetsregister/test_utils/IntegrationTest.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 abstract class IntegrationTest : RepositoryTestBase() {
 
 	companion object {

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,14 +1,3 @@
-spring.main.banner-mode=off
-server.shutdown=graceful
-
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
-management.endpoint.health.probes.enabled=true
-management.endpoint.health.group.liveness.include=livenessState
-management.endpoints.web.base-path=/internal
-management.endpoints.web.exposure.include=prometheus,health
-management.prometheus.metrics.export.enabled=true
-
 no.nav.security.jwt.issuer.azuread.discovery-url=http://localhost:8083/azuread/.well-known/openid-configuration
 no.nav.security.jwt.issuer.azuread.accepted-audience=some-audience
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,14 +1,3 @@
-spring.main.banner-mode=off
-server.shutdown=graceful
-
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
-management.endpoint.health.probes.enabled=true
-management.endpoint.health.group.liveness.include=livenessState
-management.endpoints.web.base-path=/internal
-management.endpoints.web.exposure.include=prometheus,health
-management.prometheus.metrics.export.enabled=true
-
 no.nav.security.jwt.issuer.azuread.discovery-url=${MOCK_AZURE_AD_DISCOVERY_URL:null}
 no.nav.security.jwt.issuer.azuread.accepted-audience=test
 


### PR DESCRIPTION
- Byttet ut deprikert `management.endpoint.prometheus.enabled`  med `management.endpoint.prometheus.access`. [Spring-Boot-3.4-Configuration-Changelog](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Configuration-Changelog)
- Fjernet deprikert `management.endpoint.metrics.enabled=true` fordi denne ikke er med i `management.endpoints.web.exposure.include` og er dermed overflødig.
- Fjernet entries fra application-test.properties og application-local.properties hvor nøkkel/verdi var lik som i application.properties.
- Lagt til tester for actuator-endepunktene
